### PR TITLE
Changes for CentOS8:latest containerd version manually

### DIFF
--- a/molecule/shared-resources/requirements.txt
+++ b/molecule/shared-resources/requirements.txt
@@ -7,3 +7,4 @@ molecule>=3.0a3
 molecule-ec2
 Jinja2==2.10
 testinfra==1.19.0
+molecule-docker

--- a/tasks/setup-containerd.yml
+++ b/tasks/setup-containerd.yml
@@ -12,7 +12,7 @@
 
 - name: 2.0.1.b.Install containerd on RHEL 8.
   package:
-    name: "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm"
+    name: "https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.4.4-3.1.el7.x86_64.rpm"
     state: "{{ containerd_package_state }}"
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8'
 

--- a/tasks/setup-docker-compose.yml
+++ b/tasks/setup-docker-compose.yml
@@ -23,7 +23,7 @@
     url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-{{ ansible_system }}-{{ ansible_userspace_architecture }}"
     dest: "/usr/local/bin/docker-compose"
     mode: '0755'
-    timeout: 120
+    timeout: 180
   tags:
     - install-docker-compose
     - download-docker-compose


### PR DESCRIPTION
- package docker-ce-3:20.10.5-3.el7.x86_64 requires containerd.io >= 1.4.1, but none of the providers can be installed  ,cannot install the best candidate for the job. Package containerd.io-1.4.3-3.1.el7.x86_64 is filtered out by modular filtering.
- [root@centos8-worker0000 /]# yum install docker-ce docker-ce-cli containerd.io 
Failed to set locale, defaulting to C.UTF-8
Last metadata expiration check: 0:29:17 ago on Tue Apr  6 18:14:01 2021.
Package containerd.io-1.2.6-3.3.el7.x86_64 is already installed.
Error: 
 Problem: package docker-ce-3:20.10.5-3.el7.x86_64 requires containerd.io >= 1.4.1, but none of the providers can be installed
  - cannot install the best candidate for the job
  - package containerd.io-1.4.3-3.1.el7.x86_64 is filtered out by modular filtering
  - package containerd.io-1.4.3-3.2.el7.x86_64 is filtered out by modular filtering
  - package containerd.io-1.4.4-3.1.el7.x86_64 is filtered out by modular filtering
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
So, added the latest version of containerd manually